### PR TITLE
Fix bug when collection is empty

### DIFF
--- a/lib/pagy_cursor/pagy/extras/cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/cursor.rb
@@ -30,6 +30,8 @@ class Pagy
     end
 
     def pagy_cursor_has_more?(collection, pagy)
+      return false if collection.empty?
+
       next_position = collection.last[pagy.primary_key]
       pagy_cursor_get_items(collection, pagy, next_position).exists?
     end

--- a/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
@@ -33,6 +33,8 @@ class Pagy
     end
 
     def pagy_uuid_cursor_has_more?(collection, pagy)
+      return false if collection.empty?
+
       next_position = collection.last[pagy.primary_key]
       pagy_uuid_cursor_get_items(collection, pagy, next_position).exists?
     end

--- a/spec/pagy_cursor/cursor_spec.rb
+++ b/spec/pagy_cursor/cursor_spec.rb
@@ -5,52 +5,63 @@ RSpec.describe Pagy::Backend do
 
   let(:backend) { TestController.new }
 
-  before do
-    User.destroy_all
-    1.upto(100) do |i|
-      User.create!(name: "user#{i}")
+  context 'no records' do
+    it 'returns an empty collection' do
+      pagy, records = backend.send(:pagy_cursor, User.all)
+      expect(records).to be_empty
+      expect(pagy.has_more?).to eq(false)
     end
   end
 
-  it "paginates with defaults" do
-    pagy, records = backend.send(:pagy_cursor, User.all)
-    expect(records.map(&:name)).to eq(
-      ["user100", "user99", "user98", "user97", "user96",
-        "user95", "user94", "user93", "user92", "user91",
-        "user90", "user89", "user88", "user87", "user86",
-        "user85", "user84", "user83", "user82", "user81"])
-    expect(pagy.has_more?).to eq(true)
+  context 'with records' do
+    before do
+      User.destroy_all
+      1.upto(100) do |i|
+        User.create!(name: "user#{i}")
+      end
+    end
+
+    it "paginates with defaults" do
+      pagy, records = backend.send(:pagy_cursor, User.all)
+      expect(records.map(&:name)).to eq(
+        ["user100", "user99", "user98", "user97", "user96",
+         "user95", "user94", "user93", "user92", "user91",
+         "user90", "user89", "user88", "user87", "user86",
+         "user85", "user84", "user83", "user82", "user81"])
+      expect(pagy.has_more?).to eq(true)
+    end
+
+    it "paginates with before" do
+      record = User.find_by! name: "user30"
+      pagy, records = backend.send(:pagy_cursor, User.all, before: record.id)
+      expect(records.first.name).to eq("user29")
+      expect(records.last.name).to eq("user10")
+      expect(pagy.has_more?).to eq(true)
+    end
+
+    it "paginates with before nearly starting" do
+      record = User.find_by! name: "user5"
+      pagy, records = backend.send(:pagy_cursor, User.all, before: record.id)
+      expect(records.first.name).to eq("user4")
+      expect(records.last.name).to eq("user1")
+      expect(pagy.has_more?).to eq(false)
+    end
+
+    it "paginates with after" do
+      record = User.find_by! name: "user30"
+      pagy, records = backend.send(:pagy_cursor, User.all, after: record.id)
+      expect(records.first.name).to eq("user31")
+      expect(records.last.name).to eq("user50")
+      expect(pagy.has_more?).to eq(true)
+    end
+
+    it "paginates with before nearly starting" do
+      record = User.find_by! name: "user90"
+      pagy, records = backend.send(:pagy_cursor, User.all, after: record.id)
+      expect(records.first.name).to eq("user91")
+      expect(records.last.name).to eq("user100")
+      expect(pagy.has_more?).to eq(false)
+    end
   end
 
-  it "paginates with before" do
-    record = User.find_by! name: "user30"
-    pagy, records = backend.send(:pagy_cursor, User.all, before: record.id)
-    expect(records.first.name).to eq("user29")
-    expect(records.last.name).to eq("user10")
-    expect(pagy.has_more?).to eq(true)
-  end
-
-  it "paginates with before nearly starting" do
-    record = User.find_by! name: "user5"
-    pagy, records = backend.send(:pagy_cursor, User.all, before: record.id)
-    expect(records.first.name).to eq("user4")
-    expect(records.last.name).to eq("user1")
-    expect(pagy.has_more?).to eq(false)
-  end
-
-  it "paginates with after" do
-    record = User.find_by! name: "user30"
-    pagy, records = backend.send(:pagy_cursor, User.all, after: record.id)
-    expect(records.first.name).to eq("user31")
-    expect(records.last.name).to eq("user50")
-    expect(pagy.has_more?).to eq(true)
-  end
-
-  it "paginates with before nearly starting" do
-    record = User.find_by! name: "user90"
-    pagy, records = backend.send(:pagy_cursor, User.all, after: record.id)
-    expect(records.first.name).to eq("user91")
-    expect(records.last.name).to eq("user100")
-    expect(pagy.has_more?).to eq(false)
-  end
 end

--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -4,52 +4,62 @@ require "pagy_cursor/pagy/extras/uuid_cursor"
 RSpec.describe PagyCursor do
   let(:backend) { TestController.new }
 
-  before do
-    Post.destroy_all
-    1.upto(100) do |i|
-      Post.create!(title: "post#{i}", created_at: (100-i).minutes.ago)
+  context 'no records' do
+    it 'returns an empty collection' do
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all)
+      expect(records).to be_empty
+      expect(pagy.has_more?).to eq(false)
     end
   end
 
-  it "paginates with defaults" do
-    pagy, records = backend.send(:pagy_uuid_cursor, Post.all)
-    expect(records.map(&:title)).to eq(
-      ["post100", "post99", "post98", "post97", "post96",
-        "post95", "post94", "post93", "post92", "post91",
-        "post90", "post89", "post88", "post87", "post86",
-        "post85", "post84", "post83", "post82", "post81"])
-    expect(pagy.has_more?).to eq(true)
-  end
+  context 'with records' do
+    before do
+      Post.destroy_all
+      1.upto(100) do |i|
+        Post.create!(title: "post#{i}", created_at: (100-i).minutes.ago)
+      end
+    end
 
-  it "paginates with before" do
-    record = Post.find_by! title: "post30"
-    pagy, records = backend.send(:pagy_uuid_cursor, Post.all, before: record.id)
-    expect(records.first.title).to eq("post29")
-    expect(records.last.title).to eq("post10")
-    expect(pagy.has_more?).to eq(true)
-  end
+    it "paginates with defaults" do
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all)
+      expect(records.map(&:title)).to eq(
+        ["post100", "post99", "post98", "post97", "post96",
+         "post95", "post94", "post93", "post92", "post91",
+         "post90", "post89", "post88", "post87", "post86",
+         "post85", "post84", "post83", "post82", "post81"])
+      expect(pagy.has_more?).to eq(true)
+    end
 
-  it "paginates with before nearly starting" do
-    record = Post.find_by! title: "post5"
-    pagy, records = backend.send(:pagy_uuid_cursor, Post.all, before: record.id)
-    expect(records.first.title).to eq("post4")
-    expect(records.last.title).to eq("post1")
-    expect(pagy.has_more?).to eq(false)
-  end
+    it "paginates with before" do
+      record = Post.find_by! title: "post30"
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all, before: record.id)
+      expect(records.first.title).to eq("post29")
+      expect(records.last.title).to eq("post10")
+      expect(pagy.has_more?).to eq(true)
+    end
 
-  it "paginates with after" do
-    record = Post.find_by! title: "post30"
-    pagy, records = backend.send(:pagy_uuid_cursor, Post.all, after: record.id)
-    expect(records.first.title).to eq("post31")
-    expect(records.last.title).to eq("post50")
-    expect(pagy.has_more?).to eq(true)
-  end
+    it "paginates with before nearly starting" do
+      record = Post.find_by! title: "post5"
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all, before: record.id)
+      expect(records.first.title).to eq("post4")
+      expect(records.last.title).to eq("post1")
+      expect(pagy.has_more?).to eq(false)
+    end
 
-  it "paginates with before nearly starting" do
-    record = Post.find_by! title: "post90"
-    pagy, records = backend.send(:pagy_uuid_cursor, Post.all, after: record.id)
-    expect(records.first.title).to eq("post91")
-    expect(records.last.title).to eq("post100")
-    expect(pagy.has_more?).to eq(false)
+    it "paginates with after" do
+      record = Post.find_by! title: "post30"
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all, after: record.id)
+      expect(records.first.title).to eq("post31")
+      expect(records.last.title).to eq("post50")
+      expect(pagy.has_more?).to eq(true)
+    end
+
+    it "paginates with before nearly starting" do
+      record = Post.find_by! title: "post90"
+      pagy, records = backend.send(:pagy_uuid_cursor, Post.all, after: record.id)
+      expect(records.first.title).to eq("post91")
+      expect(records.last.title).to eq("post100")
+      expect(pagy.has_more?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
This fixes the following error when a collection is empty:

![image](https://user-images.githubusercontent.com/46548/73510987-fcd8dd80-441e-11ea-8c88-e30790ad1b4b.png)

The only change is the added context of when the collection is empty (the rest of the changes in the spec are indentation changes) and the actual fix is a guard clause on `pagy_cursor_has_more?`

The same problem appears in `uuid_cursor` so I have included the fix for that as well here.
