### PR TITLE
Has more without querying again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pagy_cursor (0.1.1)
+    pagy_cursor (0.2.0)
       activerecord (>= 5)
       pagy
 
@@ -89,7 +89,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    pagy (3.7.3)
+    pagy (3.8.2)
     pg (1.2.2)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To run tests in root folder of gem:
 - ```bundle exec rspec ```
 
 To test on specific Rails verison
-```export BUNDLE_GEMFILE=gemfiles/active_record_5.2.gemfile``` to work with Rails 5.2
+```export BUNDLE_GEMFILE=gemfiles/active_record_52.gemfile``` to work with Rails 5.2
 
 To play with app cd test/dummy and rails s -b 0.0.0.0 (before rails db:migrate).
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To run tests in root folder of gem:
 - ```bundle install```
 - ```bundle exec rspec ```
 
-To test on specific Rails verison
+To test on specific Rails version
 ```export BUNDLE_GEMFILE=gemfiles/active_record_52.gemfile``` to work with Rails 5.2
 
 To play with app cd test/dummy and rails s -b 0.0.0.0 (before rails db:migrate).

--- a/lib/pagy_cursor/pagy/extras/cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/cursor.rb
@@ -10,7 +10,7 @@ class Pagy
       items =  pagy_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
 
-      return pagy, items
+      return pagy, items[0..pagy.items-1]
     end
 
     def pagy_cursor_get_vars(collection, vars)
@@ -23,17 +23,16 @@ class Pagy
     def pagy_cursor_get_items(collection, pagy, position=nil)
       if position.present?
         sql_comparation = pagy.arel_table[pagy.primary_key].send(pagy.comparation, position)
-        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
+        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items + 1)
       else
-        collection.reorder(pagy.order).limit(pagy.items)
+        collection.reorder(pagy.order).limit(pagy.items + 1)
       end
     end
 
     def pagy_cursor_has_more?(collection, pagy)
       return false if collection.empty?
 
-      next_position = collection.last[pagy.primary_key]
-      pagy_cursor_get_items(collection, pagy, next_position).exists?
+      collection.size > pagy.items
     end
   end
 end

--- a/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
@@ -9,7 +9,7 @@ class Pagy
       items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_uuid_cursor_has_more?(items, pagy)
 
-      return pagy, items
+      return pagy, items[0..pagy.items-1]
     end
 
     def pagy_uuid_cursor_get_vars(collection, vars)
@@ -29,14 +29,13 @@ class Pagy
 
         collection = collection.where(sql_comparation)
       end
-      collection.reorder(pagy.order).limit(pagy.items)
+      collection.reorder(pagy.order).limit(pagy.items + 1)
     end
 
     def pagy_uuid_cursor_has_more?(collection, pagy)
       return false if collection.empty?
 
-      next_position = collection.last[pagy.primary_key]
-      pagy_uuid_cursor_get_items(collection, pagy, next_position).exists?
+      collection.size > pagy.items
     end
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -43,4 +43,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.log_level = :debug
 end

--- a/spec/pagy_cursor/cursor_spec.rb
+++ b/spec/pagy_cursor/cursor_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Pagy::Backend do
       1.upto(100) do |i|
         User.create!(name: "user#{i}")
       end
+      sleep 1
       user = User.find_by name: "user81"
       user.update(name: "I am user81")
     end

--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe PagyCursor do
       1.upto(100) do |i|
         Post.create!(title: "post#{i}", created_at: (100-i).minutes.ago)
       end
+      sleep 1
       post = Post.find_by(title: "post91")
       post.update(title: "This is post91")
     end


### PR DESCRIPTION
Hello @Uysim ,

Apologies for the delay.

I've tried to implement has_more without re-querying. The idea is by querying `pagy.items + 1` and check whether `collection.size > pagy.items`. The return will become `items[0..pagy.items-1]` in order to correctly return the pagination result.

Please let me know your feedback.

Thank you

Uysim/pagy-cursor#15
