### PR TITLE
return as ActiveRecord::Collection. Fix issue #28

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    pagy_cursor (0.2.0)
+    pagy_cursor (0.2.1)
       activerecord (>= 5)
-      pagy
+      pagy (< 5)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +81,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.6.1)
     minitest (5.14.0)
@@ -90,7 +92,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    pagy (3.8.2)
+    pagy (4.11.0)
     pg (1.2.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -171,4 +173,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.2.29

--- a/lib/pagy_cursor/pagy/extras/cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/cursor.rb
@@ -10,7 +10,7 @@ class Pagy
       items =  pagy_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
 
-      return pagy, items[0..pagy.items-1]
+      return pagy, items.limit(pagy.items)
     end
 
     def pagy_cursor_get_vars(collection, vars)

--- a/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
@@ -9,7 +9,7 @@ class Pagy
       items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_uuid_cursor_has_more?(items, pagy)
 
-      return pagy, items[0..pagy.items-1]
+      return pagy, items.limit(pagy.items)
     end
 
     def pagy_uuid_cursor_get_vars(collection, vars)

--- a/spec/pagy_cursor/cursor_spec.rb
+++ b/spec/pagy_cursor/cursor_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Pagy::Backend do
       expect(pagy.has_more?).to eq(false)
     end
 
-    it 'is lazy' do
+    it 'returns a chainable relation' do
      _, records = backend.send(:pagy_cursor, User.all)
 
       expect(records).to be_a(ActiveRecord::Relation)

--- a/spec/pagy_cursor/cursor_spec.rb
+++ b/spec/pagy_cursor/cursor_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe Pagy::Backend do
       expect(records.last.name).to eq("user100")
       expect(pagy.has_more?).to eq(false)
     end
+
+    it 'is lazy' do
+     _, records = backend.send(:pagy_cursor, User.all)
+
+      expect(records).to be_a(ActiveRecord::Relation)
+    end
   end
 
   context 'with ordered records' do

--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe PagyCursor do
       expect(records.last.title).to eq("post100")
       expect(pagy.has_more?).to eq(false)
     end
+
+    it 'is lazy' do
+     _, records = backend.send(:pagy_cursor, User.all)
+
+      expect(records).to be_a(ActiveRecord::Relation)
+    end
   end
 
   context 'with ordered records' do

--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PagyCursor do
       expect(pagy.has_more?).to eq(false)
     end
 
-    it 'is lazy' do
+    it 'returns a chainable relation' do
      _, records = backend.send(:pagy_cursor, User.all)
 
       expect(records).to be_a(ActiveRecord::Relation)


### PR DESCRIPTION
Previously it was returned as an Array. Needs to return it as ActiveRecord::Relation.