### PR TITLE
Add Pagy#next_position to hold next scroll id

### DIFF
--- a/lib/pagy_cursor/pagy/cursor.rb
+++ b/lib/pagy_cursor/pagy/cursor.rb
@@ -2,7 +2,7 @@ class Pagy
 
   class Cursor < Pagy
     attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
-    attr_accessor :has_more
+    attr_accessor :has_more, :next_position
     alias_method :has_more?, :has_more
 
     def initialize(vars)

--- a/lib/pagy_cursor/pagy/extras/cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/cursor.rb
@@ -9,6 +9,7 @@ class Pagy
 
       items =  pagy_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
+      pagy.next_position = next_position(items, pagy) if pagy.has_more?
 
       return pagy, items
     end
@@ -32,8 +33,11 @@ class Pagy
     def pagy_cursor_has_more?(collection, pagy)
       return false if collection.empty?
 
-      next_position = collection.last[pagy.primary_key]
-      pagy_cursor_get_items(collection, pagy, next_position).exists?
+      pagy_cursor_get_items(collection, pagy, next_position(collection, pagy)).exists?
+    end
+
+    def next_position(collection, pagy)
+      collection.last[pagy.primary_key]
     end
   end
 end

--- a/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy_cursor/pagy/extras/uuid_cursor.rb
@@ -8,6 +8,7 @@ class Pagy
       pagy = Pagy::Cursor.new(pagy_uuid_cursor_get_vars(collection, vars))
       items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_uuid_cursor_has_more?(items, pagy)
+      pagy.next_position = next_position(items, pagy) if pagy.has_more?
 
       return pagy, items
     end
@@ -35,8 +36,11 @@ class Pagy
     def pagy_uuid_cursor_has_more?(collection, pagy)
       return false if collection.empty?
 
-      next_position = collection.last[pagy.primary_key]
-      pagy_uuid_cursor_get_items(collection, pagy, next_position).exists?
+      pagy_uuid_cursor_get_items(collection, pagy, next_position(collection, pagy)).exists?
+    end
+
+    def next_position(collection, pagy)
+      collection.last[pagy.primary_key]
     end
   end
 end

--- a/spec/pagy_cursor/cursor_spec.rb
+++ b/spec/pagy_cursor/cursor_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Pagy::Backend do
       pagy, records = backend.send(:pagy_cursor, User.all)
       expect(records).to be_empty
       expect(pagy.has_more?).to eq(false)
+      expect(pagy.next_position).to be(nil)
     end
   end
 
@@ -29,6 +30,7 @@ RSpec.describe Pagy::Backend do
          "user90", "user89", "user88", "user87", "user86",
          "user85", "user84", "user83", "user82", "user81"])
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with before" do
@@ -37,6 +39,7 @@ RSpec.describe Pagy::Backend do
       expect(records.first.name).to eq("user29")
       expect(records.last.name).to eq("user10")
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with before nearly starting" do
@@ -45,6 +48,7 @@ RSpec.describe Pagy::Backend do
       expect(records.first.name).to eq("user4")
       expect(records.last.name).to eq("user1")
       expect(pagy.has_more?).to eq(false)
+      expect(pagy.next_position).to be(nil)
     end
 
     it "paginates with after" do
@@ -53,6 +57,7 @@ RSpec.describe Pagy::Backend do
       expect(records.first.name).to eq("user31")
       expect(records.last.name).to eq("user50")
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with after nearly ending" do
@@ -61,6 +66,7 @@ RSpec.describe Pagy::Backend do
       expect(records.first.name).to eq("user91")
       expect(records.last.name).to eq("user100")
       expect(pagy.has_more?).to eq(false)
+      expect(pagy.next_position).to be(nil)
     end
 
     it 'returns a chainable relation' do
@@ -97,6 +103,7 @@ RSpec.describe Pagy::Backend do
          "user90", "user89", "user88", "user87", "user86",
          "user85", "user84", "user83", "user82"])
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
       expect(pagy.order[:updated_at]).to eq(:desc)
     end
   end

--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe PagyCursor do
          "post90", "post89", "post88", "post87", "post86",
          "post85", "post84", "post83", "post82", "post81"])
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with before" do
@@ -36,6 +37,7 @@ RSpec.describe PagyCursor do
       expect(records.first.title).to eq("post29")
       expect(records.last.title).to eq("post10")
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with before nearly starting" do
@@ -44,6 +46,7 @@ RSpec.describe PagyCursor do
       expect(records.first.title).to eq("post4")
       expect(records.last.title).to eq("post1")
       expect(pagy.has_more?).to eq(false)
+      expect(pagy.next_position).to be(nil)
     end
 
     it "paginates with after" do
@@ -52,6 +55,7 @@ RSpec.describe PagyCursor do
       expect(records.first.title).to eq("post31")
       expect(records.last.title).to eq("post50")
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
     end
 
     it "paginates with before nearly starting" do
@@ -60,6 +64,7 @@ RSpec.describe PagyCursor do
       expect(records.first.title).to eq("post91")
       expect(records.last.title).to eq("post100")
       expect(pagy.has_more?).to eq(false)
+      expect(pagy.next_position).to be(nil)
     end
 
     it 'returns a chainable relation' do
@@ -94,6 +99,7 @@ RSpec.describe PagyCursor do
          "post90", "post89", "post88", "post87", "post86",
          "post85", "post84", "post83", "post82", "post81"])
       expect(pagy.has_more?).to eq(true)
+      expect(pagy.next_position).to eq(records.last.id)
       expect(pagy.order[:updated_at]).to eq(:desc)
     end
   end


### PR DESCRIPTION
I'd like to give my users the next id they need to supply when they're scrolling in my response header, but the pagy instance doesn't store the collection, so we have to save it.

I want to write `response.headers["Next-Scroll-Id"] = @pagy.next_position` in my `ApplicationController` instead of adding a line to every controller with pagy results using the collection that comes back.

Thanks for the gem, BTW!