### PR TITLE
Fix one of the specs

### DIFF
--- a/spec/pagy_cursor/uuid_cursor_spec.rb
+++ b/spec/pagy_cursor/uuid_cursor_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PagyCursor do
     end
 
     it 'returns a chainable relation' do
-      _, records = backend.send(:pagy_cursor, User.all)
+      _, records = backend.send(:pagy_uuid_cursor, User.all)
  
       expect(records).to be_a(ActiveRecord::Relation)
     end


### PR DESCRIPTION
One of the uuid specs incorrectly references `pagy_cursor` instead of `pagy_uuid_cursor`.