### PR TITLE
Add Ruby 3.2 to CI and upgrade checkout action so it runs after 5/18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,14 @@ jobs:
           - ruby-version: 3.1
             env:
               BUNDLE_GEMFILE: gemfiles/active_record_70.gemfile
-
+          - ruby-version: 3.2
+            env:
+              BUNDLE_GEMFILE: gemfiles/active_record_70.gemfile
       fail-fast: false
     env: ${{ matrix.env }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
@@ -74,16 +76,19 @@ jobs:
           - ruby-version: 2.7
             env:
               BUNDLE_GEMFILE: gemfiles/active_record_52.gemfile
-          - ruby-version: 3.0
+          - ruby-version: "3.0"
             env:
               BUNDLE_GEMFILE: gemfiles/active_record_61.gemfile
           - ruby-version: 3.1
             env:
               BUNDLE_GEMFILE: gemfiles/active_record_70.gemfile
+          - ruby-version: 3.2
+            env:
+              BUNDLE_GEMFILE: gemfiles/active_record_70.gemfile
       fail-fast: false
     env: ${{ matrix.env }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR includes three changes:

- Add Ruby 3.2 to CI - Ruby 3.2 was released in December 2022, so it should be in the matrix
- Upgrade checkout action - Checkout v2 will stop working on May 18th because it has a Node v12 dependency.
- Quote 3.0 - An unquoted 3.0 is truncated to 3, loading the latest Ruby 3 (3.2.2 at time of writing) rather than the 3.0.x intended